### PR TITLE
Cursor bleeds outside of text inputs in Safari

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -12,7 +12,7 @@ export default styled.input`
   font-weight: ${weights.light};
   font-size: 16px;
   letter-spacing: 2px;
-  line-height: 50px;
+  line-height: 1.3;
   padding: 0 20px;
   margin-bottom: 20px;
   width: 100%;


### PR DESCRIPTION
Resolves #326 