### PR TITLE
Fix size of hero image in About page

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -401,7 +401,7 @@ export const query = graphql`
       nodes {
         name
         childImageSharp {
-          fluid(cropFocus: NORTH, maxHeight: 335, maxWidth: 335) {
+          fluid(cropFocus: NORTH, maxHeight: 480, maxWidth: 980) {
             ...GatsbyImageSharpFluid_withWebp
           }
         }


### PR DESCRIPTION
<img width="1256" alt="Screen Shot 2021-01-08 at 3 58 27 PM" src="https://user-images.githubusercontent.com/50171204/104063556-59fe1700-51ca-11eb-86c0-c157174e3491.png">
