### PR TITLE
Temporarily remove Google Tag manager to verify it fixes random CSS issues

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -85,20 +85,20 @@ module.exports = {
       },
     },
     `gatsby-plugin-offline`,
-    {
-      resolve: `gatsby-plugin-google-tagmanager`,
-      options: {
-        id: 'GTM-MKBKRBC',
-        includeInDevelopment: false,
-      },
-    },
-    {
-      resolve: `gatsby-plugin-gtag`,
-      options: {
-        trackingId: 'UA-46758288-8',
-        head: false,
-      },
-    },
+    // {
+    //   resolve: `gatsby-plugin-google-tagmanager`,
+    //   options: {
+    //     id: 'GTM-MKBKRBC',
+    //     includeInDevelopment: false,
+    //   },
+    // },
+    // {
+    //   resolve: `gatsby-plugin-gtag`,
+    //   options: {
+    //     trackingId: 'UA-46758288-8',
+    //     head: false,
+    //   },
+    // },
     {
       resolve: `gatsby-plugin-feed`,
       options: {


### PR DESCRIPTION
This is a work-in-progress PR to validate that Google Tag Manager scripts are causing the occasionally CSS issues on the Thirdandgrove.com website.