### PR TITLE
Landing Page Content Type

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -30,6 +30,16 @@ const runQueries = async graphql => {
             }
           }
         }
+        landingPages: allLandingPage(filter: { field_hidden: { eq: false } }) {
+          nodes {
+            id
+            title
+            drupal_internal__nid
+            path {
+              alias
+            }
+          }
+        }
         insights: allInsight(filter: { field_hidden: { eq: false } }) {
           nodes {
             id
@@ -83,6 +93,16 @@ const runQueries = async graphql => {
     queries = await graphql(`
       query {
         caseStudies: allCaseStudy(filter: { field_hidden: { eq: false } }) {
+          nodes {
+            id
+            title
+            drupal_internal__nid
+            path {
+              alias
+            }
+          }
+        }
+        landingPages: allLandingPage(filter: { field_hidden: { eq: false } }) {
           nodes {
             id
             title
@@ -153,10 +173,16 @@ exports.onCreateDevServer = ({ app }) => {
 exports.createPages = async ({ actions, graphql }) => {
   const { createPage, createRedirect } = actions;
 
-  const { caseStudies, insights, legacyInsights, redirects } = await runQueries(
-    graphql
-  );
-  const data = { data: { caseStudies, insights, legacyInsights, redirects } };
+  const {
+    caseStudies,
+    landingPages,
+    insights,
+    legacyInsights,
+    redirects,
+  } = await runQueries(graphql);
+  const data = {
+    data: { caseStudies, landingPages, insights, legacyInsights, redirects },
+  };
 
   const updatedRedirects = await updatePaths(data);
 
@@ -166,6 +192,16 @@ exports.createPages = async ({ actions, graphql }) => {
       component: path.resolve(`src/templates/studies.js`),
       context: {
         StudyId: studyData.id,
+      },
+    })
+  );
+
+  landingPages.nodes.map(landingData =>
+    createPage({
+      path: ensureTrailingSlash(landingData.path.alias),
+      component: path.resolve(`src/templates/landings.js`),
+      context: {
+        LandingId: landingData.id,
       },
     })
   );

--- a/src/templates/landings.js
+++ b/src/templates/landings.js
@@ -1,0 +1,297 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import { graphql } from 'gatsby';
+import Img from 'gatsby-image';
+
+import { fonts, weights, colors, mediaQueries, container } from '../styles';
+import Layout from '../components/layout';
+import ContentBody from '../components/ContentBody';
+import { updateExternalLinks } from '../util';
+
+const Landings = ({ data }) => {
+  const post = data.landingPage;
+  const imageSrc =
+    post.relationships.field_image &&
+    post.relationships.field_image.localFile &&
+    post.relationships.field_image.localFile.childImageSharp &&
+    post.relationships.field_image.localFile.childImageSharp.fluid;
+
+  const backgroundColor = post.field_color && post.field_color.color;
+
+  useEffect(() => updateExternalLinks(document.querySelectorAll('main a')), []);
+
+  return (
+    <Layout
+      headerData={{
+        metaTitle: post.field_meta_title || post.title,
+        description: post.field_meta_description,
+        title: post.title,
+        invert: post.field_inverse_header,
+        defaultBackground: false,
+        color: backgroundColor || colors.yellow,
+        height: '500px',
+        mobileMinHeight: '470px',
+        titleMarginBottom: '70px',
+        label: post.relationships.field_tags.map(tag => tag.name).join(', '),
+        labelMobileOnly: true,
+      }}
+    >
+      {imageSrc && (
+        <Img
+          fluid={post.relationships.field_image.localFile.childImageSharp.fluid}
+          alt={post.field_image.alt}
+          css={css`
+            margin-left: 20px;
+            margin-right: 20px;
+            margin-top: calc(-25.5% + 15px);
+            max-width: 980px;
+
+            ${mediaQueries.xs} {
+              margin-top: -165px;
+            }
+
+            ${mediaQueries.phoneLarge} {
+              margin-left: auto;
+              margin-right: auto;
+            }
+          `}
+        />
+      )}
+      <p
+        css={css`
+          ${container.min};
+          font-family: ${fonts.sans};
+          font-size: 21px;
+          font-weight: ${weights.bold};
+          line-height: 1;
+          padding: 55px 20px 0;
+          margin-bottom: 20px;
+
+          ${mediaQueries.phoneLarge} {
+            letter-spacing: normal;
+            padding: 75px 0 0;
+            margin-bottom: 60px;
+          }
+        `}
+      >
+        {post.field_subtitle}
+      </p>
+      <ContentBody comps={post.relationships.field_components} type='study' />
+    </Layout>
+  );
+};
+
+Landings.propTypes = {
+  data: PropTypes.object.isRequired,
+};
+
+export const query = graphql`
+  query($LandingId: String!) {
+    landingPage(id: { eq: $LandingId }) {
+      id
+      title
+      field_subtitle
+      field_meta_title
+      field_meta_description
+      field_image_arrangement
+      field_inverse_header
+      field_color {
+        color
+      }
+      field_image {
+        alt
+      }
+      field_secondary_image {
+        alt
+      }
+      field_tertiary_image {
+        alt
+      }
+      relationships {
+        node_type {
+          name
+        }
+        uid {
+          name: display_name
+        }
+        field_components {
+          ... on component__text_split_with_video_phone {
+            id
+            field_video_file_name
+            field_reversed
+            field_body {
+              processed
+            }
+            relationships {
+              component_type {
+                name
+              }
+            }
+          }
+          ... on component__video {
+            id
+            relationships {
+              component_type {
+                name
+              }
+            }
+            field_video_controls
+            field_vimeo_video_link {
+              uri
+            }
+          }
+          ... on component__text {
+            id
+            relationships {
+              component_type {
+                name
+              }
+            }
+            field_body {
+              processed
+            }
+          }
+          ... on component__image {
+            id
+            field_image {
+              alt
+            }
+            relationships {
+              component_type {
+                name
+              }
+              field_image {
+                id
+                localFile {
+                  publicURL
+                  childImageSharp {
+                    fluid(maxWidth: 800) {
+                      ...GatsbyImageSharpFluid_withWebp
+                    }
+                  }
+                }
+              }
+            }
+          }
+          ... on component__quote {
+            id
+            relationships {
+              component_type {
+                name
+              }
+            }
+            field_quote
+            field_footer_text
+          }
+
+          ... on component__prefooter {
+            id
+            field_primary_lead_in_text
+            field_primary_body
+            field_primary_cta {
+              uri
+              title
+            }
+            field_primary_color {
+              color
+            }
+            field_secondary_lead_in_text
+            field_secondary_body
+            field_secondary_cta {
+              uri
+              title
+            }
+            field_secondary_color {
+              color
+            }
+            field_image {
+              alt
+            }
+            relationships {
+              component_type {
+                name
+              }
+              field_image {
+                id
+                localFile {
+                  publicURL
+                  childImageSharp {
+                    fluid(maxWidth: 600, maxHeight: 600, cropFocus: CENTER) {
+                      ...GatsbyImageSharpFluid_withWebp
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          ... on component__text_image_split {
+            id
+            field_body {
+              processed
+            }
+            field_image {
+              alt
+            }
+            field_reversed
+            relationships {
+              component_type {
+                name
+              }
+              field_image {
+                id
+                localFile {
+                  publicURL
+                  childImageSharp {
+                    fluid(maxWidth: 800, cropFocus: CENTER) {
+                      ...GatsbyImageSharpFluid_withWebp
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        field_tags {
+          name
+        }
+        field_image {
+          id
+          localFile {
+            publicURL
+            childImageSharp {
+              fluid(maxWidth: 980, maxHeight: 500, cropFocus: CENTER) {
+                ...GatsbyImageSharpFluid_withWebp
+              }
+            }
+          }
+        }
+        field_secondary_image {
+          id
+          localFile {
+            publicURL
+            childImageSharp {
+              fluid(maxWidth: 800, maxHeight: 600) {
+                ...GatsbyImageSharpFluid_withWebp
+              }
+            }
+          }
+        }
+        field_tertiary_image {
+          id
+          localFile {
+            publicURL
+            childImageSharp {
+              fluid(maxWidth: 800, maxHeight: 600) {
+                ...GatsbyImageSharpFluid_withWebp
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default Landings;

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -21,20 +21,34 @@ module.exports = {
   updatePaths: json => {
     return new Promise((resolve, reject) => {
       return [json.data].map(
-        ({ caseStudies, insights, legacyInsights, redirects }) => {
-          if (!caseStudies || !insights || !legacyInsights || !redirects) {
+        ({
+          caseStudies,
+          landingPages,
+          insights,
+          legacyInsights,
+          redirects,
+        }) => {
+          if (
+            !caseStudies ||
+            !landingPages ||
+            !insights ||
+            !legacyInsights ||
+            !redirects
+          ) {
             const error = new Error('missing dependency');
             reject(error);
             throw error;
           }
 
           const caseStudyNodes = caseStudies.nodes;
+          const landingPageNodes = landingPages.nodes;
           const insightsNodes = insights.nodes;
           const legacyInsightsNodes = legacyInsights.nodes;
           const updatedRedirects = [];
           const nodeArray = caseStudyNodes.concat(
             insightsNodes,
-            legacyInsightsNodes
+            legacyInsightsNodes,
+            landingPageNodes
           );
 
           redirects.edges.forEach(({ node }) => {


### PR DESCRIPTION
Description:

We need to add another template that follow the same pattern as the case studies does currently. https://github.com/thirdandgrove/thirdandgrove-com-gatsby/blob/6d92b3f15e5be6499d210094fee30c68fdd14569/src/templates/studies.js

This file uses paragraphs to create a flexible content model. The model passes data from Drupal to tell the component  <ContentBody comps={post.relationships.field_components} type='study' /> You can find the component switching here → https://github.com/thirdandgrove/thirdandgrove-com-gatsby/blob/e95733188cc4ee31daf54d6361ac08452d477ad6/src/components/ContentBody/ContentBody.js

The component that ContentBody is set up to use does satisfy the requirements of this ticket those will need to be added but it is possible that a developer could follow the same pattern as the studies to allow the current set of components and add to that. 

A developer could duplicate the caseStudy content type in Drupal and then using the other tickets add those other fields and component types. https://thirdandgrove.atlassian.net/browse/T5-356 https://thirdandgrove.atlassian.net/browse/T5-358

The other piece of this ticket is setting up pathing and path aliases in Drupal and configuring the gatsby.node.js file to make sure that the paths work at the root of the url. 

ACCEPTANCE CRITERIA:

A new Landing Page content type is created

paragraphs module should be installed/enabled

Ability to add paragraphs to content type should be created

Gatsby front end should be able to render any paragraph components in any order on the page, determined by their order in the drupal backend 

This should build out a unpublished node that contains lorem ipsum for all available paragraph types/fields